### PR TITLE
facilitate both CentOS and RHEL as base boxes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,6 @@
-export RHN_USERNAME=majortom
-export RHN_PASSWORD=canyouhearme
+# VM_BOX=geerlingguy/centos7 # confirmed working as of 9/3/2018, this is the default
+# VM_BOX=samdoran/rhel7 # confirmed working as of 9/5/2018
+
+# the following are *required* if you intend to use a RHEL-based box
+# export RHN_USERNAME=majortom
+# export RHN_PASSWORD=canyouhearme

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+export RHN_USERNAME=majortom
+export RHN_PASSWORD=canyouhearme

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ imagemagick_sources
 config/local-bootstrap.sh
 ^config/local-bootstrap.sh.example
 files/*
+.env

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is totally a work in progress, use at your own risk.
 * [Vagrant](http://vagrantup.com/) version 1.8.3 or above.
 * [VirtualBox](https://www.virtualbox.org/)
 * (Optional) A GitHub account with an associated SSH key. This is NOT required, but if you plan to do development with this project and/or create Pull Requests, it is recommended. If you have a local [SSH agent](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) running (or [Pageant/PuTTY](http://www.putty.org/) on Windows, or the [OSX Keychain with a saved passphrase](https://apple.stackexchange.com/questions/48502/how-can-i-permanently-add-my-ssh-private-key-to-keychain-so-it-is-automatically)), Vagrant will attempt to automatically forward your local SSH key(s) to the VM, so that you will be able to immediately interact with GitHub via SSH on the VM. However, if you are *not* running a key agent, *even if your SSH key does not have a passphrase*, Vagrant will *not* prompt you to enter your passphrase, it will simply fail to run all the provisioning processes. We urge you to consider running a key agent with your SSH key, it will make your life so much more simple.
- * *WARNING:* If you are using an SSH key, we highly recommend that you use an RSA key. The base OS we use, Ubuntu 16.04LTS, uses OpenSSH 7.0, which [*disallows* DSA keys by default](http://viryagroup.com/what-we-do/our-blog-posts/hosting-and-linux-server-managment-blog/ssh-keys-failing-in-ubuntu-16-04-xenial-with-permission-denied-publickey). You can of course work around this, but OpenSSH made this choice for a reason, you will probably be happier in the long run if you switch to an RSA key.
+ * *WARNING:* If you are using an SSH key, we highly recommend that you use an RSA key.
 
 ## Do I need to install Ansible?
 
@@ -21,19 +21,19 @@ No, this project uses the [Ansible Local Provisioner](https://www.vagrantup.com/
 
 ## How to use
 
-Standard Vagrant protocol: clone this repository, cd to the root of it, and run
+Ensure you have the Vagrant-ENV plugin installed (see below), clone this repository, cd to the root of it, then copy the `.env.sample` file to a new file called `.env`, and modify it to suit your requirements. You may select either a CentOS base box, or you can use a RHEL base box. If you opt for a RHEL base box, you will also need to provide your RHN credentials in your `.env` file. The box will not provision correctly without these credentials. For CentOS, no RHN credentials are required, and should not be provided.
+
+After preparing your .env file, standard Vagrant protocol applies: be sure you're in the top level folder of this project, and run
 
 ```
 vagrant up
 ```
 
-## Vagrant Plugin Recommendations
+## Vagrant Plugin Requirements and Recommendations
 
 Vagrant has a robust community of plugin developers, and some of the plugins are quite nice. [Installing a Vagrant plugin](https://www.vagrantup.com/docs/plugins/usage.html) is simple.
 
-The following Vagrant plugin is *highly-recommended*, if you use a base box with a small drive space allocation (many base box images do this to minimize download time). Installing the Vagrant-Disksize plugin is a good insurance policy, and will help.
-
-* [Vagrant-Disksize](https://github.com/sprotheroe/vagrant-disksize)
+The [Vagrant-ENV](https://github.com/gosuri/vagrant-env) Vagrant plugin is *required*, in order to use this project.
 
 The following Vagrant plugins are not required, but they do make using Vagrant more enjoyable.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
 
   # If our .env file contains a key for VM_BOX, use it, otherwise use geerlingguy's centos7 box
   if ENV.has_key? 'VM_BOX'
-    config.vm.box = "ENV['VM_BOX']"
+    config.vm.box = ENV['VM_BOX']
   else
     config.vm.box = "geerlingguy/centos7"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,11 +12,22 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  #config.vm.box = "ubuntu/xenial64"
+  # config.vm.box = "geerlingguy/centos7" confirmed working as of 9/3/2018
 
-  # use my Samvera-Basebox
-#  config.vm.box = "hardyoyo/Samvera-Basebox"
-  config.vm.box = "geerlingguy/centos7"
+  if Vagrant.has_plugin?('vagrant-env')
+    config.env.enable # enable the .env plugin
+  end
+
+  # the vagrant-registration plugin does not seem to actually attach a subscription, but still unattaches on halt
+  # so we'll keep it around, even though it doesn't really work
+  config.vm.box = "sgurnick/rhel7" # NOTE: requires a valid RHEL developer subscription
+  if Vagrant.has_plugin?('vagrant-registration')
+    config.registration.username = "ENV['RHN_USERNAME']"
+    config.registration.password = "ENV['RHN_PASSWORD']"
+  end
+
+  # and now we *really* register and attach our RHN subscription
+  config.vm.provision :shell, :name => "attach RHN subscription", :inline => "source /vagrant/.env && subscription-manager register --auto-attach --username=$RHN_USERNAME --password=$RHN_PASSWORD"
 
   #skip the inserting of a key, because it's problematic and not needed
   config.ssh.insert_key = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
 
   # the vagrant-registration plugin does not seem to actually attach a subscription, but still unattaches on halt
   # so we'll keep it around, even though it doesn't really work
-  config.vm.box = "sgurnick/rhel7" # NOTE: requires a valid RHEL developer subscription
+  config.vm.box = "samdoran/rhel7" # NOTE: requires a valid RHEL developer subscription
   if Vagrant.has_plugin?('vagrant-registration')
     config.registration.username = "ENV['RHN_USERNAME']"
     config.registration.password = "ENV['RHN_PASSWORD']"

--- a/download-installers.sh
+++ b/download-installers.sh
@@ -39,7 +39,7 @@ fi
 
 # Copy Tomcat to the location where the role looks for it
 if [ -f /vagrant/files/apache-tomcat-7.0.67.tar.gz ]; then
-  echo 'Copying Tomcat to role download location...'
-  cp /vagrant/files/apache-tomcat-7.0.67.tar.gz /usr/local/apache-tomcat-7.0.67.tar.gz
+  echo 'symlinking Tomcat to role download location...'
+  ln -s /vagrant/files/apache-tomcat-7.0.67.tar.gz /usr/local/apache-tomcat-7.0.67.tar.gz
 fi
 exit 0


### PR DESCRIPTION
This PR enables a user of this project to specify the base box they wish to use, and if that base box is RHEL, the RHN credentials can be added to a .env file. This PR also documents how all this is supposed to work.